### PR TITLE
Fix critical bugs, improve docs, and add testing infrastructure

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,6 @@
+^\.Rproj\.user$
+^.*\.Rproj$
+^\.github$
+^\.claude$
+^README\.md$
+^LICENSE\.md$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,43 @@
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: ubuntu-latest,  r: 'release'}
+          - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,17 +1,18 @@
 Package: evobiR
 Type: Package
 Title: Evolutionary Biology in R
-Version: 2.1
-Date: 2023-5-13
+Version: 2.2
+Date: 2025-02-20
 Author: Michelle M. Jonika, Maximos Chin, Nathan Anderson, Richard H. Adams, Jeffery P. Demuth, and Heath Blackmon
 Maintainer: Heath Blackmon <coleoguy@gmail.com>
 URL: https://github.com/coleoguy/evobir
+BugReports: https://github.com/coleoguy/evobir/issues
 Description: Comparative analysis of continuous traits influencing discrete states, and utility tools to facilitate comparative analyses.  Implementations of ABBA/BABA type statistics to test for introgression in genomic data.
 License: GPL (>=2)
 Imports:
-     seqinr, 
-     ape, 
-     geiger, 
+     seqinr,
+     ape,
+     geiger,
      phytools,
      castor,
      methods,
@@ -19,6 +20,7 @@ Imports:
      RColorBrewer,
      expm,
      igraph
-Suggests: knitr
+Suggests: knitr, testthat (>= 3.0.0)
+Config/testthat/edition: 3
 VignetteBuilder: knitr
 

--- a/R/AncCond.R
+++ b/R/AncCond.R
@@ -41,9 +41,9 @@
 
 AncCond <- function(tree, data, mc = 1000, drop.state=NULL, mat=c(0,2,1,0), pi="equal", n.tails = 1, message = TRUE) {
   ##### testing inputs #####
-  if(is(tree) != 'phylo') {stop('tree must be class phylo')}
-  if(!is.data.frame(data) & ncol(data) == 3){stop('data should be a dataframe with 3 columns\n(tip labels, cont data, discrete data)')}
-  if (is.numeric(mc) | round(mc) == mc){stop('mc should be a numeric positive integer integer')}
+  if(!inherits(tree, 'phylo')) {stop('tree must be class phylo')}
+  if(!is.data.frame(data) | ncol(data) != 3){stop('data should be a dataframe with 3 columns\n(tip labels, cont data, discrete data)')}
+  if (!is.numeric(mc) | round(mc) != mc){stop('mc should be a numeric positive integer')}
   if(!is.null(drop.state)) if(!drop.state %in% c(1,2)){stop('drop.state must be NULL, or numeric 1 or 2')}
   if(!sum(mat == c(0,0,1,0)) == 4 & !sum(mat == c(0,1,1,0)) == 4 & !sum(mat == c(0,2,1,0)) == 4){
     stop('mat must be a vector of the form c(0,0,1,0), c(0,1,1,0), or c(0,2,1,0)')

--- a/R/CalcD.R
+++ b/R/CalcD.R
@@ -378,4 +378,5 @@ CalcPopD <- function(alignment = "alignment.fasta",
   user.result$align.length <- ncol(alignment.matrix) - 1
   user.result$useful.sites <- results[[2]]
   user.result$seg.sites <- results[[3]]
+  return(user.result)
 }

--- a/R/FuzzyMatch.R
+++ b/R/FuzzyMatch.R
@@ -1,5 +1,5 @@
 FuzzyMatch <- function(tree, data, max.dist){
-  if(is(tree)=="multiPhylo"){
+  if(inherits(tree, "multiPhylo")){
     warning("Multiple trees were supplied only first is being used")
     tree <- tree[[1]]
   }

--- a/R/GetTipRates.R
+++ b/R/GetTipRates.R
@@ -34,9 +34,11 @@ GetTipRates <- function(tree = NULL,
          a probability matrix to create tip states for given data.")
   }
   
-  #if tip states are not integers, stop function and ask user to resolve
-  if(is.integer(tip.states)){
-    stop("\n Tip states are not integers. Please provide tip states as integers.")
+  #if tip states are provided, check they are numeric whole numbers
+  if(!is.null(tip.states)){
+    if(!is.numeric(tip.states) || any(tip.states != round(tip.states))){
+      stop("\n Tip states are not whole numbers. Please provide tip states as integers.")
+    }
   }
   
   #if tip states are not present, but a probability matrix is provided, fill in 

--- a/R/WinCalcD.R
+++ b/R/WinCalcD.R
@@ -55,9 +55,7 @@ WinCalcD <- function(alignment = "alignment.fasta", win.size = 100, step.size=50
       z <- abs(d/sd(sim.d, na.rm = T))
       z[is.nan(z)] <- 0
       new.pval <- 2 * (1 - pnorm(z))
-      ## NOW WE MAKE THE OUTPUTS  
-      cat("\n\n TEST FUNCTION\n\n")
-      print(sim.d)
+      ## NOW WE MAKE THE OUTPUTS
       cat("\nSites in alignment =", ncol(alignment.matrix))
       cat("\nNumber of sites with ABBA pattern =", abba)
       cat("\nNumber of sites with BABA pattern =", baba)

--- a/R/countTrees.R
+++ b/R/countTrees.R
@@ -26,7 +26,7 @@ countTrees <- function(collection = NULL, ref = NULL, classes=T, verbose=T){
   }
   if(verbose){
     if(length(bad)>0){
-      print(paste("Some trees do match available topologies. You may want to check trees:", bad))
+      print(paste("Some trees do not match available topologies. You may want to check trees:", bad))
     }
   }
   if(classes==T){

--- a/R/make.simmap2.R
+++ b/R/make.simmap2.R
@@ -127,11 +127,11 @@ make.simmap2 <- function (tree, x, model="SYM", nsim=1, monitor = FALSE, rejmax 
       if (pm) 
         printmessage(Q, pi, method = "fixed")
       
-      mtrees <- replicate(nsim,
-                          c(sim <<- sim + 1,
-                            if(monitor == TRUE){print(paste("simulation", sim, "of", nsim, sep = " "))},
-                            smap2(tree, x, N, m, root, L, Q, pi, logL, rejmax, rejint, monitor, sim)),
-                          simplify = FALSE)
+      mtrees <- vector("list", nsim)
+      for(sim in 1:nsim){
+        if(monitor == TRUE){print(paste("simulation", sim, "of", nsim, sep = " "))}
+        mtrees[[sim]] <- smap2(tree, x, N, m, root, L, Q, pi, logL, rejmax, rejint, monitor, sim)
+      }
     }
     if (nsim==1) {
       mtrees <- mtrees[[1]]

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,7 +1,7 @@
 .onAttach <- function(libname, pkgname) {
   packageStartupMessage("\nThank you for using evobiR!\n")
   packageStartupMessage("\nTo acknowledge our work, please cite the package: \n")
-  packageStartupMessage(" Michelle M. Jonika, Maximos Chin, Nathan Anderson, Richard H. Adams, Jeffery P. Demuth, and Heath Blackmon. (2023).") 
+  packageStartupMessage(" Michelle M. Jonika, Maximos Chin, Nathan Anderson, Richard H. Adams, Jeffery P. Demuth, and Heath Blackmon. (2025).")
   packageStartupMessage(" EvobiR: Tools for comparative analyses and teaching evolutionary biology.")
-  packageStartupMessage(" coleoguy/evobiR: EvobiR version 2.1 \n")
+  packageStartupMessage(" coleoguy/evobiR: EvobiR version 2.2 \n")
 }

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,15 @@
+bibentry(
+  bibtype  = "Manual",
+  title    = "evobiR: Tools for Comparative Analyses and Teaching Evolutionary Biology",
+  author   = c(
+    person("Michelle M.", "Jonika"),
+    person("Maximos", "Chin"),
+    person("Nathan", "Anderson"),
+    person("Richard H.", "Adams"),
+    person("Jeffery P.", "Demuth"),
+    person("Heath", "Blackmon")
+  ),
+  year     = "2025",
+  note     = "R package version 2.2",
+  url      = "https://github.com/coleoguy/evobir"
+)

--- a/man/1.fasta.Rd
+++ b/man/1.fasta.Rd
@@ -2,8 +2,13 @@
 \alias{1.fasta}
 \alias{3.fasta}
 \docType{data}
-\title{simulated SNP data}
-\description{This file contains simulated SNP data}
+\title{Simulated SNP alignment data}
+\description{Simulated SNP alignment files in FASTA format for use with the D-statistic functions.
+
+\code{1.fasta} contains 4 sequences representing single individuals in the order P1, P2, P3, and Outgroup, for use with \code{\link{CalcD}} and \code{\link{WinCalcD}}.
+
+\code{3.fasta} contains population-level data with multiple sequences per population (sequences from the same population share identical names), for use with \code{\link{CalcPopD}}.
+}
 \references{http://coleoguy.github.io/}
 \author{Heath Blackmon}
 \keyword{datasets}

--- a/man/AncCond.Rd
+++ b/man/AncCond.Rd
@@ -1,45 +1,56 @@
 \name{AncCond}
 \alias{AncCond}
-\title{Calculate the mean of a continuous character at transitions in a binary charachter}
+\title{Calculate the mean of a continuous character at transitions in a binary character}
 \description{This function uses ancestral state estimations for a discrete character based on stochastic mapping under an Mk2 model and ancestral state estimates for a continuous trait under a Brownian motion model to determine if transitions in the binary trait coincide with extreme values of a continuous trait.}
 \usage{
-AncCond(tree, 
-        data, 
-        mc = 1000, 
-        drop.state=NULL, 
-        mat=c(0,2,1,0), 
-        pi="equal", 
-        n.tails = 1, 
+AncCond(tree,
+        data,
+        mc = 1000,
+        drop.state=NULL,
+        mat=c(0,2,1,0),
+        pi="equal",
+        n.tails = 1,
         message = TRUE)
 }
 \arguments{
-  \item{tree}{tree of class phylo}
-  \item{data}{a dataframe with 3 columns. The first should match the taxa names in the tree, the second should have the continuous trait values and the third the states for the binary character. The binary trait should be coded as 1 and 2 if one is ancestral then it must be coded as 1.}
-    \item{mc}{the number of iterations to use in building the null distribution.}
-    \item{drop.state}{\code{NULL} or a numeric value of 1 or 2. If 1 or 2 are given then continuous data from species in the specified state will be dropped from the reconstruction of the continuous character.}
-    \item{mat}{a vector describing the possible transition for the discrete trait. The default is equivelant to APE's \code{"ARD"} model \code{c(0,2,1,0)}, other options are \code{c(0,0,1,0)} which would allow only for transition from state 1 to state 2 or \code{c(0,1,1,0)} which would allow for transition in either direction but at equal rates.}
-    \item{pi}{The probabilities for the binary trait at the root of the tree. The values possible are \code{"equal"}, \code{"estimated"}, or a numeric vector of length 2 with probabilities for each state}
+  \item{tree}{a phylogenetic tree of class \code{phylo}}
+  \item{data}{a dataframe with 3 columns. The first should match the taxa names in the tree, the second should have the continuous trait values and the third the states for the binary character. The binary trait should be coded as 1 and 2; if one is ancestral then it must be coded as 1.}
+    \item{mc}{the number of iterations to use in building the null distribution}
+    \item{drop.state}{\code{NULL} or a numeric value of 1 or 2. If 1 or 2 are given then continuous data from species in the specified state will be dropped from the reconstruction of the continuous character. Defaults to \code{NULL}.}
+    \item{mat}{a vector describing the possible transitions for the discrete trait. The default is equivalent to APE's \code{"ARD"} model \code{c(0,2,1,0)}, other options are \code{c(0,0,1,0)} which would allow only for transitions from state 1 to state 2 or \code{c(0,1,1,0)} which would allow for transitions in either direction but at equal rates.}
+    \item{pi}{the probabilities for the binary trait at the root of the tree. The values possible are \code{"equal"}, \code{"estimated"}, or a numeric vector of length 2 with probabilities for each state}
     \item{n.tails}{numeric value of 1 or 2 to indicate whether a 1 or 2 tailed p-value should be calculated}
-    \item{message}{Logical value if \code{TRUE} then status messages will be printed to the console}
+    \item{message}{logical value; if \code{TRUE} then status messages will be printed to the console}
 
 }
-\details{This function uses ancestral state estimates to determine if the transitions in the binary trait are associated with extreme values of the continuous trait.  This test can incorporate the possibility that the derived state of a binary character may lead to correlated selection in the continuous trait.  If this is desired then the drop.state argument should be used to specify the derived state of the binary character that should not be used in the ancestral state estimation of the continuous trait.}
+\details{This function uses ancestral state estimates to determine if the transitions in the binary trait are associated with extreme values of the continuous trait. This test can incorporate the possibility that the derived state of a binary character may lead to correlated selection in the continuous trait. If this is desired then the \code{drop.state} argument should be used to specify the derived state of the binary character that should not be used in the ancestral state estimation of the continuous trait.
 
-\value{Returns a list of length 4:
-  \item{OriginatingVals}{the mean value(s) for the continuous trait at the transition points of the binary character}
-  \item{NTrans}{the number of transitions in the binary character}
-  \item{NullDist}{the null distribution(s) produced by simulation}
-  \item{pval}{pvalue}
+When \code{mat = c(0,2,1,0)} (the default ARD model), the function returns a list of length 8 with results for transitions in both directions (1->2 and 2->1). When \code{mat = c(0,0,1,0)} (irreversible model), the function returns a list of length 4 with results for transitions from state 1 to state 2 only.}
 
+\value{Returns a named list. When using a reversible model (default), the list has 8 elements:
+  \item{OriginatingVals1->2}{the mean value for the continuous trait at nodes producing transitions from state 1 to state 2}
+  \item{NTrans1->2}{the number of 1->2 transitions in the binary character}
+  \item{NullDist1->2}{the null distribution produced by simulation for 1->2 transitions}
+  \item{pval1->2}{p-value for 1->2 transitions}
+  \item{OriginatingVals2->1}{the mean value for the continuous trait at nodes producing transitions from state 2 to state 1}
+  \item{NTrans2->1}{the number of 2->1 transitions}
+  \item{NullDist2->1}{the null distribution produced by simulation for 2->1 transitions}
+  \item{pval2->1}{p-value for 2->1 transitions}
 
+When using an irreversible model, the list has 4 elements:
+  \item{OriginatingVals}{the mean value for the continuous trait at transition points}
+  \item{NTrans}{the number of transitions}
+  \item{NullDist}{the null distribution produced by simulation}
+  \item{pval}{p-value}
 }
 \author{Nathan Anderson, Jeffery P. Demuth, Richard H. Adams, and Heath Blackmon}
 \references{http://coleoguy.github.io/}
 \examples{
-\dontrun{
+\donttest{
 data(mite.trait)
 data(trees.mite)
-AncCond(trees[[1]], mite.trait) 
+result <- AncCond(trees[[1]], mite.trait)
+result$pval
 }
 }
 \keyword{ comparative method }

--- a/man/CalcD.Rd
+++ b/man/CalcD.Rd
@@ -2,26 +2,35 @@
 \alias{CalcD}
 \alias{CalcPopD}
 \title{Calculate Patterson's D-statistic}
-\description{These functions calculate Patterson's D-statistic to compare the frequencies of discordant SNP genealogies.  These tests assume equal substitution rates and unlinked loci, D-statistics significantly different from 0 suggest that introgression has occurred.}
+\description{These functions calculate Patterson's D-statistic to compare the frequencies of discordant SNP genealogies. These tests assume equal substitution rates and unlinked loci; D-statistics significantly different from 0 suggest that introgression has occurred. \code{CalcD} uses single sequences per taxon while \code{CalcPopD} uses population-level data with multiple sequences per population.}
 \usage{
-CalcD(alignment = "alignment.fasta", sig.test = "N", ambig="D", 
+CalcD(alignment = "alignment.fasta", sig.test = "N", ambig="D",
 block.size = 1000, replicate = 1000, align.format='fasta')
 
-CalcPopD(alignment = "alignment.fasta", sig.test = "N", ambig="D", 
+CalcPopD(alignment = "alignment.fasta", sig.test = "N", ambig="D",
 block.size = 1000, replicate = 1000, align.format='fasta')
 
 }
 \arguments{
-  \item{alignment}{This is an alignment in fasta format.  Sequences should be in the order: P1, P2, P3, Outgroup.  In the case of CalcPopD sequence from each populations should have identical names see file 3.fasta for an example}
-  \item{sig.test}{This indicates whether or if to test for significance. Options are "B" bootstrap, "J" jackknife, or "N" none.}
-  \item{ambig}{This flag indicate how to deal with sequence ambiguities. Options are "D" drop all ambigous loci, "R" resolve each biallelic ambiguity, or "I" ignore ambiguity and perform analysis without checking sequences.  If the argument "R"" is chosen there is becomes a degree of stochasticity in the analysis and the user should run the analysis more than once.  Also it would be wise to compare this result to setting the argument to "D".}
-  \item{block.size}{The number of sites to be dropped in the jackknife approach}
-  \item{replicate}{Number of replicates to be used in estimating variance}
-  \item{align.format}{a character string specifying the format of the alignment file : mase, clustal, phylip, fasta or msf}
+  \item{alignment}{path to an alignment file. Sequences should be in the order: P1, P2, P3, Outgroup. In the case of \code{CalcPopD}, sequences from each population should have identical names (see file 3.fasta for an example).}
+  \item{sig.test}{indicates whether and how to test for significance. Options are \code{"B"} bootstrap, \code{"J"} jackknife, or \code{"N"} none.}
+  \item{ambig}{flag indicating how to deal with sequence ambiguities. Options are \code{"D"} drop all ambiguous loci, \code{"R"} resolve each biallelic ambiguity randomly, or \code{"I"} ignore ambiguity and perform analysis without checking sequences. If the argument \code{"R"} is chosen there is a degree of stochasticity in the analysis and the user should run the analysis more than once. It is also wise to compare this result to setting the argument to \code{"D"}.}
+  \item{block.size}{the number of sites to be dropped in the jackknife approach}
+  \item{replicate}{number of replicates to be used in estimating variance}
+  \item{align.format}{a character string specifying the format of the alignment file: \code{"mase"}, \code{"clustal"}, \code{"phylip"}, \code{"fasta"}, or \code{"msf"}}
 }
-\details{The functions CalcD and CalcPopD are implementations of the algorithm described in Durand et al. 2011.  Significance of the D-stat can be calculated either through bootstrapping or jackknifing.  Bootstrapping is appropriate for datasets where SNPs are unlinked for instance unmapped RADSeq data.  Jackknifing is the appropriate approach when SNPs are potentially in linkage for instance gene alignments or genome alignments.}
+\details{The functions \code{CalcD} and \code{CalcPopD} are implementations of the algorithm described in Durand et al. 2011. Significance of the D-statistic can be calculated either through bootstrapping or jackknifing. Bootstrapping is appropriate for datasets where SNPs are unlinked, for instance unmapped RADSeq data. Jackknifing is the appropriate approach when SNPs are potentially in linkage, for instance gene alignments or genome alignments.}
 \value{
-Returns the number of each type of site, Z scores and p-values
+\code{CalcD} returns the D-statistic as a numeric value.
+
+\code{CalcPopD} returns a list with the following elements:
+  \item{d.stat}{the D-statistic}
+  \item{pval}{the p-value (only present when \code{sig.test} is not \code{"N"})}
+  \item{align.length}{the number of sites in the alignment}
+  \item{useful.sites}{the number of sites with ABBA or BABA patterns}
+  \item{seg.sites}{the number of ABBA/BABA sites still segregating in at least one population}
+
+Both functions also print summary statistics to the console.
 }
 \author{Heath Blackmon}
 \references{http://coleoguy.github.io/

--- a/man/GetTipRates.Rd
+++ b/man/GetTipRates.Rd
@@ -1,19 +1,42 @@
 \name{GetTipRates}
 \alias{GetTipRates}
 \title{Calculate the rate of evolution on the leaves of a phylogeny}
-\description{This function calculates the rate of change from parent nodes to extant tips of a phylogeny.}
+\description{This function calculates the rate of change from parent nodes to extant tips of a phylogeny. It uses ancestral state reconstruction via the Mk model (implemented in \pkg{castor}) to estimate states at internal nodes, then computes the rate of change along each terminal branch as the absolute difference between the parent node state and tip state divided by the branch length.}
 \usage{
-GetTipRates(tree, Q, tip.states, hyper, p.mat)
+GetTipRates(tree = NULL, Q = NULL, tip.states = NULL,
+            hyper = FALSE, p.mat = NULL)
 }
 \arguments{
-  \item{tree}{an ultrametric tree of class phylo}
-  \item{Q}{transition matrix containing estimated rates with column names}
-  \item{tip.states}{An integer vector with a length equal to the number of species on the phylogeny. It should have values of 1 to N with N being the number of total states. Elements of the vector should match the tip names for the phylogeny.}
-  \item{hyper}{logical vector of length one. TRUE indicates the model includes a binary hyperstate. Default is FALSE and indicates no binary hyperstate}
-  \item{p.mat}{a probability matrix where each column represent a discrete state and each row is a species. Values in the matrix describe the probability of being in any of these states}
+  \item{tree}{an ultrametric tree of class \code{phylo}}
+  \item{Q}{a transition matrix containing estimated rates with column names. Column names should correspond to the actual state values.}
+  \item{tip.states}{a named numeric vector with a length equal to the number of species on the phylogeny. Values should be integers from 1 to N where N is the number of total states. Names should match the tip labels of the phylogeny. Can be \code{NULL} if \code{p.mat} is provided.}
+  \item{hyper}{logical; \code{TRUE} indicates the model includes a binary hyperstate (state labels contain an 'h' prefix that will be stripped). Defaults to \code{FALSE}.}
+  \item{p.mat}{a probability matrix where each column represents a discrete state and each row is a species. Values describe the probability of being in each state. Row names should match tree tip labels. Used to generate \code{tip.states} when \code{tip.states} is \code{NULL}. Defaults to \code{NULL}.}
 }
 
-\value{A named numeric vector with the rate for each tip in the phylogeny.}
+\value{A named numeric vector with the rate of change for each tip in the phylogeny. Names correspond to tip labels.}
 \author{Michelle M. Jonika and Heath Blackmon}
 \references{http://coleoguy.github.io/}
-\keyword{comparative phylogenetics, q-matrix, discrete trait}
+\examples{
+\donttest{
+## Create a simple example
+library(ape)
+tree <- rtree(10)
+tree <- chronos(tree)
+class(tree) <- "phylo"
+
+## Define a simple 2-state Q matrix
+Q <- matrix(c(-0.5, 0.5, 0.5, -0.5), 2, 2)
+colnames(Q) <- rownames(Q) <- c("1", "2")
+
+## Create tip states
+tip.states <- sample(1:2, 10, replace = TRUE)
+names(tip.states) <- tree$tip.label
+
+## Calculate tip rates
+rates <- GetTipRates(tree = tree, Q = Q, tip.states = tip.states, hyper = FALSE)
+rates
+}
+}
+\keyword{comparative phylogenetics}
+\keyword{discrete trait}

--- a/man/Pfsa.Rd
+++ b/man/Pfsa.Rd
@@ -3,7 +3,7 @@
 \alias{Pfaa}
 \alias{Pfss}
 \title{Calculate the proportion of different classes of fusions as a fraction of all fusions}
-\description{Thes three functions, Pfsa, Pfaa, and Pfss use sex chromosome systems and diploid autosome number to calculate the proportion of all fusions that are expected to be sex chromosome autosome fusions (Pfsa), autosome autosome fusions (Pfaa), and sex chromosome sex chromosome fusions (Pfss). }
+\description{These three functions use sex chromosome systems and diploid autosome number to calculate the proportion of all fusions that are expected to be sex chromosome-autosome fusions (\code{Pfsa}), autosome-autosome fusions (\code{Pfaa}), and sex chromosome-sex chromosome fusions (\code{Pfss}).}
 \usage{
 Pfsa(Da, scs, mud)
 Pfaa(Da, scs, mud)
@@ -11,14 +11,18 @@ Pfss(Da, scs, mud)
 }
 \arguments{
   \item{Da}{the diploid autosome count}
-  \item{scs}{a text string describing the sex chromosome system for instance: "XO", "XXO", "XY", "ZO"", or "ZWW"}
-    \item{mud}{the proportion of fusions that originate in females.}
+  \item{scs}{a text string describing the sex chromosome system, for instance: \code{"XO"}, \code{"XXO"}, \code{"XY"}, \code{"ZO"}, or \code{"ZWW"}}
+    \item{mud}{the proportion of fusions that originate in females. Defaults to 0.5.}
 }
-\details{This approach assumes that all chromosomes have equal probability of being involved in a fusion and that X and Y (or Z and W) chromosomes are not able to fuse. It will provide accurate results for any sex chromosome system that has any number of one sex chromosomes and either zero or one of the other. For instance it will work for XO, XY, XXY, XYYYY, but not for XXYY. It is applicable to both male and female heterogameic systems.}
+\details{This approach assumes that all chromosomes have equal probability of being involved in a fusion and that X and Y (or Z and W) chromosomes are not able to fuse with each other. It will provide accurate results for any sex chromosome system that has any number of one sex chromosome and either zero or one of the other. For instance it will work for XO, XY, XXY, XYYYY, but not for XXYY. It is applicable to both male and female heterogametic systems.}
 
 \value{Returns a numeric vector of length 1 which contains the proportion of fusions expected to be of the specified type.}
 \author{Nathan Anderson and Heath Blackmon}
 \references{http://coleoguy.github.io/}
-\examples{Pfsa(Da = 26, scs = "XY", mud=0.4)}
+\examples{
+Pfsa(Da = 26, scs = "XY", mud = 0.4)
+Pfaa(Da = 26, scs = "XY", mud = 0.4)
+Pfss(Da = 26, scs = "XY", mud = 0.4)
+}
 \keyword{ sex chromosome }
 \keyword{ fusion }

--- a/man/ReOrderAlignment.Rd
+++ b/man/ReOrderAlignment.Rd
@@ -1,19 +1,23 @@
 \name{ReOrderAlignment}
 \alias{ReOrderAlignment}
-%- Also NEED an '\alias' for EACH other topic documented here.
 \title{Re-order sequences based on starting position}
 \description{
-This function re-orders aligned sequences with sequences based on the site of the alignment that they first have data. It also allows user to select reference sequences that will stay at the top of the alignmment regardless of starting position.  
+This function re-orders aligned sequences based on the site of the alignment where they first have data (i.e., the first non-gap position). It also allows the user to select reference sequences that will stay at the top of the alignment regardless of starting position. This is useful for visual inspection of alignments where sequences begin at different positions.
 }
 \usage{
-ReOrderAlignment(file, newfile, ref = "")
+ReOrderAlignment(file, newfile, ref = NULL)
 }
-%- maybe also 'usage' for other objects documented here.
 \arguments{
-  \item{file}{the name of the fasta file which has sequences need to be re-ordered}
-  \item{newfile}{name of the output file}
-  \item{ref}{Either an integer or a characrter vector. Elements of the vector should match the sequences that should be kept at the top of the alignment.}
+  \item{file}{path to the fasta file containing sequences to be re-ordered}
+  \item{newfile}{path for the output fasta file}
+  \item{ref}{either an integer vector of sequence indices or a character vector of sequence names. Elements should identify the sequences that should be kept at the top of the alignment. Defaults to \code{NULL} (no reference sequences).}
 }
-\value{A fasta file}
+\value{Writes a re-ordered fasta file to \code{newfile}. Called for its side effect.}
 \references{http://coleoguy.github.io/}
 \author{Sean Chien and Heath Blackmon}
+\examples{
+\donttest{
+ReOrderAlignment(file = system.file("1.fasta", package = "evobiR"),
+                 newfile = tempfile(fileext = ".fasta"))
+}
+}

--- a/man/SampleTrees.Rd
+++ b/man/SampleTrees.Rd
@@ -1,22 +1,24 @@
 \name{SampleTrees}
 \alias{SampleTrees}
 \title{Select a random sample of trees}
-\description{This function takes as its input a large collection of trees from a program like MrBayes or Beast and allows the user to select the number of randomly drawn trees they wish to retrieve}
+\description{This function takes as its input a large collection of trees from a program like MrBayes or BEAST, removes a user-specified proportion as burn-in, and randomly samples a desired number of trees from the post-burn-in distribution.}
 \usage{SampleTrees(trees, burnin, final.number, format, prefix)}
 \arguments{
-  \item{trees}{a nexus format file containing trees that the user wants to sample from}
-  \item{burnin}{the proportion of trees to remove as burnin}
-  \item{final.number}{the number of trees desired}
-  \item{format}{options are "new" or "nex" indicating to save the trees in newick format or nexus format}
-  \item{prefix}{a text string to assing to the new treefile name
-}
+  \item{trees}{path to a nexus format file containing trees that the user wants to sample from}
+  \item{burnin}{the proportion of trees to remove as burn-in (e.g., 0.25 removes the first 25\%)}
+  \item{final.number}{the number of trees desired in the final sample}
+  \item{format}{output format: \code{"new"} for Newick format or \code{"nex"} for Nexus format}
+  \item{prefix}{a text string to assign as the prefix of the new tree file name}
 }
 \value{
-an object of the class "multiPhylo" is returned
+Writes the sampled trees to a file and returns an object of class \code{multiPhylo}.
 }
 \references{\url{http://coleoguy.github.io/}}
 \author{Heath Blackmon}
 \examples{
-SampleTrees(trees = system.file("trees.nex", package = "evobiR"), 
-            burnin = .1, final.number = 20, format = 'new', prefix = 'sample')}
+\donttest{
+SampleTrees(trees = system.file("trees.nex", package = "evobiR"),
+            burnin = .1, final.number = 20, format = 'new', prefix = 'sample')
+}
+}
 \keyword{ phylogenetics }

--- a/man/SlidingWindow.Rd
+++ b/man/SlidingWindow.Rd
@@ -3,19 +3,24 @@
 \title{
 Sliding window analysis}
 \description{
-Applies a function within a sliding window of a numeric vector or matrix.  Both the step size and the window size can be set by the user.  For the matrix impelentation the step size and window size is constrained to be the same in both the X and Y dimensions.}
+Applies a function within a sliding window of a numeric vector or matrix. Both the step size and the window size can be set by the user. For the matrix implementation the step size and window size is constrained to be the same in both the X and Y dimensions.}
 \usage{
 SlidingWindow(FUN, data, window, step, strict)
 }
 \arguments{
-  \item{FUN}{a function to be applied within each window.}
+  \item{FUN}{a function to be applied within each window (as a character string, e.g. \code{"mean"})}
   \item{data}{a numerical vector or matrix}
   \item{window}{an integer setting the size of the window}
   \item{step}{an integer setting the size of step between windows}
-  \item{strict}{TRUE or FALSE indicating whether validation testing should be performed}
+  \item{strict}{\code{TRUE} or \code{FALSE} indicating whether validation testing should be performed. Defaults to \code{FALSE}.}
 }
 \details{
-If the input data is a vector then returns a vector of numeric values representing the application of the selected function within each window.  If the input data is a matrix then returns a matrix of numeric values representing the application fo the selected function within each window.}
+If the input data is a vector then the function is applied to each window of the specified size, stepping through the vector by the step size. If the input data is a matrix then the function is applied to square submatrices of the specified window size, stepping through both rows and columns by the step size.}
+\value{
+If \code{data} is a vector, returns a numeric vector of values representing the application of the selected function within each window.
+
+If \code{data} is a matrix, returns a numeric matrix of values representing the application of the selected function within each square window.
+}
 \references{
 \url{http://coleoguy.github.io/}}
 \author{

--- a/man/SuperMatrix.Rd
+++ b/man/SuperMatrix.Rd
@@ -1,28 +1,30 @@
 \name{SuperMatrix}
 \alias{SuperMatrix}
 \title{
-creates a supermatrix from multiple gene alignments}
+Create a supermatrix from multiple gene alignments}
 \description{
-combines all alignments in a folder into a single supermatrix}
+Combines all alignments in a folder into a single supermatrix. Missing data is inserted for taxa that are absent from individual alignments. Partition boundaries are tracked so the user knows which columns correspond to which input alignment.}
 \usage{
 SuperMatrix(missing = "-", prefix = "concatenated", save = T,
 input = "", format.in = "f", format.out = "f", concatenate = T)
 }
 \arguments{
-  \item{missing}{the character to use when no data is available for a taxa}
-  \item{prefix}{prefix for the resulting supermatrix}
-  \item{save}{if True then supermatrix and partition file will be saved}
-  \item{input}{a regular expression determining which files will be read in for example "*.fasta" will read in all files which end in ".fasta". Default is blank and will result in all files in the working directory being read in.}
-  \item{format.in}{A character string specifying the format of the alignments to be read in. The argument is passed to read.dna in APE: "interleaved", "sequential", "clustal", or "fasta", or abbreviations of these are available.}
-  \item{format.out}{A character string specifying the format for the supermatrix to be saved to. The argument is passed to write.dna in APE: "interleaved", "sequential", "clustal", or "fasta", or abbreviations of these are available.}
-  \item{concatenate}{logical value when TRUE sequences are concatenated into a single fasta file.  When set to FALSE sequences are saved as individual fasta files but are expanded to include all taxa in combined dataset.}
-
-
+  \item{missing}{the character to use when no data is available for a taxon. Defaults to \code{"-"}.}
+  \item{prefix}{prefix for the resulting supermatrix output files. Defaults to \code{"concatenated"}.}
+  \item{save}{logical; if \code{TRUE} then supermatrix and partition files will be saved to the working directory. Defaults to \code{TRUE}.}
+  \item{input}{a regular expression determining which files will be read in. For example, \code{".fasta"} will read in all files containing ".fasta" in their names. Default is blank and will result in all files in the working directory being read in.}
+  \item{format.in}{a character string specifying the format of the alignments to be read in. Passed to \code{read.dna} in \pkg{ape}: \code{"interleaved"}, \code{"sequential"}, \code{"clustal"}, or \code{"fasta"}, or abbreviations of these.}
+  \item{format.out}{a character string specifying the format for the supermatrix to be saved to. Passed to \code{write.dna} in \pkg{ape}: \code{"interleaved"}, \code{"sequential"}, \code{"clustal"}, or \code{"fasta"}, or abbreviations of these.}
+  \item{concatenate}{logical; when \code{TRUE} sequences are concatenated into a single alignment. When \code{FALSE} sequences are saved as individual files but are expanded to include all taxa in the combined dataset. Defaults to \code{TRUE}.}
 }
 \details{
-This function reads all alignments in the working directory and constructs a single supermatrix that includes all taxa present in any of the files and inserts missing symbols for taxa that are missing sequences for some loci.}
+This function reads all alignments in the working directory (or those matching the \code{input} pattern) and constructs a single supermatrix that includes all taxa present in any of the files and inserts missing symbols for taxa that are missing sequences for some loci.}
 \value{
-A list with two elements is returned. The first element contains partition data that records the alignment positions of each input alignment file in the combined supermatrix.  The second element is a dataframe version of the supermatrix. If the argument save is set to TRUE then both of these files are also saved to the working directory.
+A list with two elements:
+  \item{partitions}{a dataframe with columns for partition name, start position, and stop position recording the alignment boundaries of each input file in the combined supermatrix}
+  \item{supermatrix}{a character matrix of the combined supermatrix}
+
+If \code{save = TRUE}, both files are also saved to the working directory.
 }
 \references{
 \url{http://coleoguy.github.io/}}
@@ -32,8 +34,10 @@ Heath Blackmon
 
 \examples{
 \dontrun{
-SuperMatrix(missing = "N", prefix = "DATASET2", save = T, format = "f")
+SuperMatrix(missing = "N", prefix = "DATASET2", save = TRUE,
+            format.in = "f", format.out = "f")
 }
 }
-\keyword{ concatention alignment DNA fasta }
-\keyword{ SuperMatrix, concatenation, alignment }
+\keyword{ concatenation }
+\keyword{ alignment }
+\keyword{ supermatrix }

--- a/man/countTrees.Rd
+++ b/man/countTrees.Rd
@@ -1,18 +1,36 @@
 \name{countTrees}
 \alias{countTrees}
 \title{Calculate the number of times a set of topologies occur}
-\description{This function counts the number of times that a set of topologies is present in a collection of trees.}
+\description{This function counts the number of times that a set of reference topologies is present in a collection of trees. Trees are compared using topology only (branch lengths are ignored). This is useful for summarizing posterior distributions of trees from Bayesian phylogenetic analyses.}
 \usage{
 countTrees(collection = NULL, ref = NULL, classes = T, verbose=T)
 }
 \arguments{
   \item{collection}{path to a collection of trees in a Newick format file}
-  \item{ref}{path to a Newick format file with the topologies of interest}
-  \item{classes}{if T then will return a vector with classification of each tree}
-  \item{verbose}{returns intermediate progress messages if TRUE}
+  \item{ref}{path to a Newick format file with the reference topologies of interest}
+  \item{classes}{logical; if \code{TRUE} then returns both topology counts and a classification vector assigning each tree to a topology. Defaults to \code{TRUE}.}
+  \item{verbose}{logical; if \code{TRUE} prints progress messages. Defaults to \code{TRUE}.}
 }
 
-\value{If classes is T returns a list with the first element being a numeric vector of the same length as the number of trees in the ref file. The elements of the returned vector correspond to the occurences of trees in the collection file that match the topologies supplied in the ref file. The second element is a vector the same length as the input tree collection and each tree is assigned a number based on the topology it matches.}
+\value{If \code{classes} is \code{TRUE}, returns a list with two elements:
+  \item{counts}{a numeric vector with length equal to the number of reference topologies. Each element gives the count of trees in the collection matching that topology.}
+  \item{classification}{a numeric vector with length equal to the number of trees in the collection. Each tree is assigned the number of the reference topology it matches, or \code{NA} if it does not match any.}
+
+If \code{classes} is \code{FALSE}, returns only the counts vector.
+}
 \author{Heath Blackmon}
 \references{http://coleoguy.github.io/}
+\examples{
+\donttest{
+## Create example tree files
+library(ape)
+## Write 50 random trees to a file
+trees <- rmtree(50, 5)
+write.tree(trees, file = tempfile(fileext = ".nwk"))
+
+## Write 3 reference topologies
+refs <- rmtree(3, 5)
+write.tree(refs, file = tempfile(fileext = ".nwk"))
+}
+}
 \keyword{tree topology}

--- a/man/evobiR-package.Rd
+++ b/man/evobiR-package.Rd
@@ -4,20 +4,20 @@
 \docType{package}
 \title{evobiR: Evolutionary Biology in R
 }
-\description{\pkg{evobiR} is a collection of tools for use in evolutionary biology.  Some of the functions manipulate data in a way not implemented by other functions while others calculate sequence statistics or perform simulations, either of data across trees or genetic and genomic simulations. }
+\description{\pkg{evobiR} is a collection of tools for use in evolutionary biology. Functions include comparative methods for analyzing the relationship between continuous and discrete traits on phylogenies, implementations of Patterson's D-statistic for testing introgression, tools for manipulating sequence alignments and phylogenetic trees, and utility functions for sliding window analyses, residual selection, and population genetics calculations.}
 \details{
 \tabular{ll}{
 Package: \tab evobiR\cr
 Type: \tab Package\cr
-Version: \tab 1.1\cr
-Date: \tab 2017-5-05\cr
+Version: \tab 2.2\cr
+Date: \tab 2025-02-20\cr
 License: \tab GPL (>=2)\cr
 }
 More information on \pkg{evobiR} is available at \url{https://github.com/coleoguy/evobir}
 
 }
 \author{
-Heath Blackmon
+Michelle M. Jonika, Maximos Chin, Nathan Anderson, Richard H. Adams, Jeffery P. Demuth, and Heath Blackmon
 
 Maintainer: Heath Blackmon <coleoguy@gmail.com>
 }

--- a/man/fix.simmap.Rd
+++ b/man/fix.simmap.Rd
@@ -1,22 +1,50 @@
 \name{fix.simmap}
 \alias{fix.simmap}
 \title{Fix a stochastic map with failed edges}
-\description{This function facilitates automated resolution of failed edges in a modified stochastic map produced by \code{\link{make.simmap2}} through application of graph theory implemented in \pkg{igraph}.}
+\description{This function facilitates automated resolution of failed edges in a modified stochastic map produced by \code{\link{make.simmap2}} through application of graph theory implemented in \pkg{igraph}. For each failed edge, it finds the shortest path between the start and end states using the transition matrix and assigns equal time to each transitional state along the path.}
 \usage{
 fix.simmap(hists, tips, transition.matrix)
 }
 \arguments{
-  \item{hists}{an object of class \code{simmap} or \code{multiSimmap} produced by \code{\link{make.simmap2}}}
-  \item{tips}{two column dataframe with first column listing species name as shown in tree tips and second column listing model state for each species}
-  \item{transition.matrix}{square matrix describing possible transitions between states}
+  \item{hists}{an object of class \code{simmap} or \code{multiSimmap} produced by \code{\link{make.simmap2}} that contains one or more failed edges}
+  \item{tips}{a two-column dataframe with the first column listing species names as shown in tree tip labels and the second column listing the known state for each species}
+  \item{transition.matrix}{a square matrix describing possible transitions between states. Non-zero entries indicate that a direct transition is possible between those states.}
 }
-\value{A object of class \code{simmap} or \code{multiSimmap}, see \code{\link{make.simmap}}. 
+\value{An object of class \code{simmap} or \code{multiSimmap}, see \code{\link{make.simmap}}.
 
-All edges which failed in the original stochastic maps should be resolved.
+All edges which were assigned a \code{"fail"} state in the original stochastic maps will be resolved with inferred transitional histories.
 }
 \seealso{
   \code{\link{make.simmap2}}
 }
 \author{Maximos Chin, Matthew Marano, and Heath Blackmon}
 \references{http://coleoguy.github.io/}
-\keyword{comparative phylogenetics, discrete trait, stochastic mapping}
+\examples{
+\donttest{
+library(ape)
+library(phytools)
+## Simulate a tree and discrete character
+tree <- rtree(20)
+x <- sample(c("a","b"), 20, replace = TRUE)
+names(x) <- tree$tip.label
+
+## Run stochastic mapping with low rejection limit
+result <- make.simmap2(tree, x, model = "ER", nsim = 1,
+                       rejmax = 10)
+
+## Create tips dataframe
+tips <- data.frame(species = tree$tip.label, state = x)
+
+## Create transition matrix
+trans.mat <- matrix(c(0, 1, 1, 0), 2, 2)
+rownames(trans.mat) <- colnames(trans.mat) <- c("a", "b")
+
+## Fix any failed edges
+if(!is.null(result$fail)){
+  fixed <- fix.simmap(result, tips, trans.mat)
+}
+}
+}
+\keyword{comparative phylogenetics}
+\keyword{discrete trait}
+\keyword{stochastic mapping}

--- a/man/horn.beetle.Rd
+++ b/man/horn.beetle.Rd
@@ -1,6 +1,10 @@
 \name{horn.beetle.csv}
 \alias{horn.beetle.csv}
 \docType{data}
-\title{Gnatocerus measurements}
-\description{A csv file containing measurements of horn and body size for the beetle Gnatocerus cornutus.}
+\title{Gnatocerus cornutus measurements}
+\description{A csv file containing measurements of horn and body size for the broad-horned flour beetle \emph{Gnatocerus cornutus}. The file has three columns: individual ID, body size, and horn size. Used in the \code{\link{ResSel}} function examples for demonstrating residual selection analysis.}
+\examples{
+data <- read.csv(file = system.file("horn.beetle.csv", package = "evobiR"))
+head(data)
+}
 \keyword{datasets}

--- a/man/hym.tree.Rd
+++ b/man/hym.tree.Rd
@@ -1,6 +1,10 @@
 \name{hym.tree}
 \alias{hym.tree}
 \docType{data}
-\title{Phylogenetic tree}
-\description{This is a phylogenetic tree with 5 species of hymenoptera.}
+\title{Hymenoptera phylogenetic tree}
+\description{A phylogenetic tree of class \code{phylo} containing 5 species of Hymenoptera (bees, wasps, and ants). Used in examples for the \code{\link{FuzzyMatch}} function to demonstrate fuzzy matching of taxon names between data and trees.}
+\examples{
+data(hym.tree)
+plot(hym.tree)
+}
 \keyword{datasets}

--- a/man/make.simmap2.Rd
+++ b/man/make.simmap2.Rd
@@ -1,29 +1,45 @@
 \name{make.simmap2}
 \alias{make.simmap2}
 \title{Modified stochastic mapping which is resistant to model failure}
-\description{This function is an extension of the \code{make.simmap} function of \pkg{phytools} which allows users to monitor rejections at specific edges during the simulation proces and set an upper limit on the number of rejections permitted per edge.}
+\description{This function is an extension of the \code{make.simmap} function of \pkg{phytools} which allows users to monitor rejections at specific edges during the simulation process and set an upper limit on the number of rejections permitted per edge. When the rejection limit is exceeded for a given edge, it is assigned a \code{"fail"} state rather than causing the entire simulation to stall. Failed edges can later be resolved using \code{\link{fix.simmap}}.}
 \usage{
 make.simmap2(tree, x, model="SYM", nsim=1 ,
-             monitor = FALSE, rejmax = NULL, rejint = 1000000, 
+             monitor = FALSE, rejmax = NULL, rejint = 1000000,
              ...)
 }
 \arguments{
-  \item{tree}{see \code{\link{make.simmap}}}
-  \item{x}{see \code{\link{make.simmap}}}
-  \item{model}{see \code{\link{make.simmap}}}
-  \item{nsim}{see \code{\link{make.simmap}}}
-    \item{monitor}{\code{boolean} describing whether or not to print number of rejections per edge to console. Defaults to \code{FALSE}}
-  \item{rejmax}{\code{int} greater than one giving the maximum number of rejections permitted before an edge is skipped. Defaults to \code{NULL} (no upper limit on rejections)}
-  \item{rejint}{\code{int} giving the interval after which rejection number is to be printed to console}
-  \item{...}{optional arguments. see \code{\link{make.simmap}}}
+  \item{tree}{a phylogenetic tree of class \code{phylo} or \code{multiPhylo}. See \code{\link{make.simmap}} for details.}
+  \item{x}{a named vector or matrix of tip states. See \code{\link{make.simmap}} for details.}
+  \item{model}{a character string or matrix describing the model. Options include \code{"ER"}, \code{"SYM"}, \code{"ARD"}, or a custom rate matrix. See \code{\link{make.simmap}} for details.}
+  \item{nsim}{number of stochastic maps to simulate. Defaults to 1.}
+    \item{monitor}{logical; whether or not to print the number of rejections per edge to the console. Defaults to \code{FALSE}.}
+  \item{rejmax}{integer giving the maximum number of rejections permitted before an edge is skipped. Defaults to \code{NULL} (no upper limit on rejections).}
+  \item{rejint}{integer giving the interval at which the rejection count is printed to the console (when \code{monitor = TRUE}). Defaults to 1000000.}
+  \item{...}{optional arguments passed to \code{\link{make.simmap}}, such as \code{Q}, \code{pi}, \code{burnin}, \code{samplefreq}, or \code{prior}.}
 }
-\value{A object of class \code{simmap} or \code{multiSimmap}, see \code{\link{make.simmap}}. 
+\value{An object of class \code{simmap} (if \code{nsim = 1}) or \code{multiSimmap} (if \code{nsim > 1}). See \code{\link{make.simmap}} for general structure.
 
-In addition to the states present in the model, an additional state \code{fail} in the \code{maps} and \code{mapped.edge} elements is assigned to edges which are skipped due to exceeding the rejection limit.
+In addition to the states present in the model, an additional state \code{"fail"} in the \code{maps} and \code{mapped.edge} elements is assigned to edges which are skipped due to exceeding the rejection limit. A \code{fail} element on the tree object lists the edge indices that failed.
 }
 \seealso{
-  \code{\link{make.simmap}}
+  \code{\link{make.simmap}}, \code{\link{fix.simmap}}
 }
 \author{Matthew Marano, Maximos Chin, and Heath Blackmon}
 \references{http://coleoguy.github.io/}
-\keyword{comparative phylogenetics, discrete trait, stochastic mapping}
+\examples{
+\donttest{
+library(ape)
+library(phytools)
+## Simulate a tree and discrete character
+tree <- rtree(20)
+x <- sample(c("a","b"), 20, replace = TRUE)
+names(x) <- tree$tip.label
+
+## Run stochastic mapping with rejection monitoring
+result <- make.simmap2(tree, x, model = "ER", nsim = 1,
+                       monitor = FALSE, rejmax = 100000)
+}
+}
+\keyword{comparative phylogenetics}
+\keyword{discrete trait}
+\keyword{stochastic mapping}

--- a/man/mite.trait.Rd
+++ b/man/mite.trait.Rd
@@ -1,6 +1,16 @@
 \name{mite.trait}
 \alias{mite.trait}
 \docType{data}
-\title{phenotype data for mites}
-\description{A dataframe of sexual system and chromosome number data for mites.  The first column has species names, the second column has diploid numbers, and the third column contains 0 and 1 to indicate diplodiploidy or haplodiploidy sex determination.}
+\title{Phenotype data for mites}
+\description{A dataframe of sexual system and chromosome number data for mites. Contains three columns:
+\describe{
+  \item{Column 1}{species names matching the tip labels of \code{\link{trees.mite}}}
+  \item{Column 2}{diploid chromosome numbers (continuous trait)}
+  \item{Column 3}{sex determination system coded as 0 (diplodiploidy) or 1 (haplodiploidy) (discrete binary trait)}
+}
+Used in examples for the \code{\link{AncCond}} function.}
+\examples{
+data(mite.trait)
+head(mite.trait)
+}
 \keyword{datasets}

--- a/man/plot.phyloscaled.Rd
+++ b/man/plot.phyloscaled.Rd
@@ -1,7 +1,7 @@
 \name{plot}
 \alias{plot.phyloscaled}
-\title{Phylogenetic visualization of heterogenity in discrete character evolution}
-\description{This function provides two methods for visualizing a \code{phyloscaled} tree produced by \code{scaleTreeRates}.}
+\title{Phylogenetic visualization of heterogeneity in discrete character evolution}
+\description{This function provides two methods for visualizing a \code{phyloscaled} tree produced by \code{\link{scaleTreeRates}}.}
 \usage{
 \method{plot}{phyloscaled}(tree, method = "multiply", palette = "RdYlGn",
      edge.width = 1, cex = 1, show.tip.label = T)
@@ -9,23 +9,37 @@
 
 
 \arguments{
-  \item{tree}{a tree of class \code{phylo} and \code{phyloscaled}}
-  \item{method}{a \code{string} describing the method to be used for visualization. Can either be "multiply" or "color", see \strong{Details}}
-  \item{palette}{a \code{string} giving the palette to be used for edge coloring, only taken into account if \code{method = "color"}. See \strong{Details}}
+  \item{tree}{a tree of class \code{phylo} and \code{phyloscaled}, as produced by \code{\link{scaleTreeRates}}}
+  \item{method}{a string describing the method to be used for visualization. Can either be \code{"multiply"} or \code{"color"}, see \strong{Details}.}
+  \item{palette}{a string giving the palette to be used for edge coloring, only taken into account if \code{method = "color"}. See \strong{Details}.}
   \item{edge.width}{numeric value that determines branch width}
-  \item{cex}{numeric value for size}
+  \item{cex}{numeric value for tip label size}
   \item{show.tip.label}{logical indicating whether to print tip labels}
 }
 \details{The two plotting methods currently supported are \code{"multiply"} and \code{"color"}.
 
-\code{multiply} takes the length of each edge on the phylogeny and multiplies it by the scalar associated with the edge before plotting the scaled tree.
+\code{"multiply"} takes the length of each edge on the phylogeny and multiplies it by the scalar associated with the edge before plotting the scaled tree. This produces a tree where branch lengths reflect the estimated rate variation.
 
-\code{color} assigns a color from a diverging palette to each edge depending on it's associated scalar. Currently supported palettes are any of the \pkg{RColorBrewer} palettes or the standard viridis palette (specified by string \code{"viridis"}). Because RColorBrewer sets the maximum number of distinct colors for divergent palettes to be 11, any phylogeny which has greater than 11 unique scalar bins represented within it's edges must use a viridis palette. The ultrametric phylogeny is then plotted with each edge colored accordingly
+\code{"color"} assigns a color from a diverging palette to each edge depending on its associated scalar. Currently supported palettes are any of the \pkg{RColorBrewer} diverging palettes or the standard viridis palette (specified by string \code{"viridis"}). Because \pkg{RColorBrewer} sets the maximum number of distinct colors for divergent palettes to be 11, any phylogeny which has greater than 11 unique scalar bins represented within its edges will automatically use the viridis palette. The ultrametric phylogeny is then plotted with each edge colored accordingly.
 }
-\value{A plotted phylogeny with edges either multiplied or colored by their associated scalars}
+\value{A plotted phylogeny with edges either multiplied or colored by their associated scalars. Called for its side effect (plotting).}
 \seealso{
   \code{\link{scaleTreeRates}}
 }
 \author{Maximos Chin and Heath Blackmon}
 \references{http://coleoguy.github.io/}
-\keyword{comparative phylogenetics, discrete trait, rate heterogeneity}
+\examples{
+\donttest{
+## Requires a phyloscaled tree from scaleTreeRates
+library(ape)
+library(phytools)
+tree <- rtree(20)
+tip.states <- sample(1:2, 20, replace = TRUE)
+names(tip.states) <- tree$tip.label
+scaled.tree <- scaleTreeRates(tree, tip.states, model = "ER", nbins = 3, max.ratio = 2)
+plot(scaled.tree, method = "multiply")
+}
+}
+\keyword{comparative phylogenetics}
+\keyword{discrete trait}
+\keyword{rate heterogeneity}

--- a/man/scaleTreeRates.Rd
+++ b/man/scaleTreeRates.Rd
@@ -1,25 +1,42 @@
 \name{scaleTreeRates}
 \alias{scaleTreeRates}
-\title{Phylogeneitc analysis  of heterogeneity in discrete character evolution}
-\description{This function performs the phylogenetic methods for analysis of heterogenity in rates of discrete character evolution described in Jonika et al. (2023).}
+\title{Phylogenetic analysis of heterogeneity in discrete character evolution}
+\description{This function performs the phylogenetic methods for analysis of heterogeneity in rates of discrete character evolution described in Jonika et al. (2023). It estimates a scalar multiplier for each edge of the phylogeny that modifies the overall transition rate matrix, allowing rates to vary across the tree.}
 \usage{
-scaleTreeRates(tree, tip.states, model, fixedQ = NULL, 
-               max.ratio = 2, nbins = 10, max.transition = 1, 
+scaleTreeRates(tree, tip.states, model, fixedQ = NULL,
+               max.ratio = 2, nbins = 10, max.transition = 1,
                var.start = FALSE, pi = "fitzjohn")
 }
 \arguments{
   \item{tree}{a tree of class \code{phylo}}
-  \item{tip.states}{a named vector of tip states for some discrete character which is associated with the phylogeny. Order can differ from order of tips on phylogeny}
-  \item{model}{the model which should be used to perform likelihod calculations. This can either be a  \code{string} which can be passed to the \code{fitMk} function of \pkg{phytools} or a symmetrical transition \code{matrix} which has transitions between states categorized into some number of distinct classes}
-  \item{fixedQ}{optional argument to be used when Q-matrix with pre-estimated rates is available. Deafults to \code{NULL}}
-  \item{max.ratio}{\code{num} or \code{int} greater than one descirbing the maximum ratio of scalar bins to one. Defaults to 2, i.e. scalar bins range between 0.5 and 2}
-  \item{nbins}{\code{int} giving the number of scalar bins above and below 1. Defaults to 10, i.e. 10 bins below 1 and 10 bins above 1 for a total of 21 bins inclusive of 1}
-  \item{max.transition}{\code{int} giving the maximum number of bins which the scalar associated with an edge can differ from the scalar associated with it's parent edge. Defaults to 1}
-  \item{var.start}{\code{logical} whether or not to increment scalar values at the root of the tree. If \code{TRUE}, the analysis will be iterated across all pssible root scalar values and the best tree (highest likelihood) returned. If \code{FALSE} (default), root scalar is set to one and only a single iteration is performed}
-  \item{pi}{\code{string} giving method to be used for estimating prior. Takes any option which can be passed to phytool's \code{fitMk}, defaults to \code{"fitzjohn"}}
+  \item{tip.states}{a named vector of tip states for some discrete character which is associated with the phylogeny. Order can differ from order of tips on phylogeny.}
+  \item{model}{the model to be used for likelihood calculations. This can either be a \code{string} which can be passed to the \code{fitMk} function of \pkg{phytools} (e.g. \code{"ER"}, \code{"SYM"}, \code{"ARD"}) or a symmetrical transition \code{matrix} which has transitions between states categorized into distinct rate classes.}
+  \item{fixedQ}{optional argument to be used when a Q-matrix with pre-estimated rates is available. Defaults to \code{NULL}, in which case rates are estimated using \code{fitMk}.}
+  \item{max.ratio}{numeric value greater than one describing the maximum ratio of scalar bins to one. Defaults to 2, i.e. scalar bins range between 0.5 and 2.}
+  \item{nbins}{integer giving the number of scalar bins above and below 1. Defaults to 10, i.e. 10 bins below 1 and 10 bins above 1 for a total of 21 bins inclusive of 1.}
+  \item{max.transition}{integer giving the maximum number of bins which the scalar associated with an edge can differ from the scalar associated with its parent edge. Defaults to 1.}
+  \item{var.start}{logical; whether or not to try all possible scalar values at the root of the tree. If \code{TRUE}, the analysis will be iterated across all possible root scalar values and the best tree (highest likelihood) returned. If \code{FALSE} (default), root scalar is set to one and only a single iteration is performed.}
+  \item{pi}{string giving method to be used for estimating the root prior. Takes any option which can be passed to \pkg{phytools}' \code{fitMk}. Defaults to \code{"fitzjohn"}.}
 }
 \value{A phylogeny of class \code{phylo} and \code{phyloscaled}. Phylogeny has all elements normally included in an object of class \code{phylo}, with an additional element:
-\item{scalar}{a \code{numeric} vector of scalars equal in length to the number of edges in phylogeny. Ordering of scalars is identical to the ordering of edges}}
+\item{scalar}{a \code{numeric} vector of scalars equal in length to the number of edges in phylogeny. Ordering of scalars is identical to the ordering of edges. Values greater than 1 indicate faster rates on that edge; values less than 1 indicate slower rates.}}
+\seealso{
+  \code{\link{plot.phyloscaled}}
+}
 \author{Maximos Chin and Heath Blackmon}
 \references{http://coleoguy.github.io/}
-\keyword{comparative phylogenetics, discrete trait, rate heterogeneity}
+\examples{
+\donttest{
+## Simple example with simulated data
+library(ape)
+library(phytools)
+tree <- rtree(20)
+tip.states <- sample(1:2, 20, replace = TRUE)
+names(tip.states) <- tree$tip.label
+result <- scaleTreeRates(tree, tip.states, model = "ER", nbins = 3, max.ratio = 2)
+result$scalar
+}
+}
+\keyword{comparative phylogenetics}
+\keyword{discrete trait}
+\keyword{rate heterogeneity}

--- a/man/trees.mite.Rd
+++ b/man/trees.mite.Rd
@@ -2,6 +2,10 @@
 \alias{trees.mite}
 \alias{trees}
 \docType{data}
-\title{10 Phylogenetic trees}
-\description{These are trees from a previously published work on mite sexual system evolution.}
+\title{10 phylogenetic trees for mites}
+\description{A \code{multiPhylo} object containing 10 phylogenetic trees from a previously published study on mite sexual system evolution. These trees can be used with the associated \code{\link{mite.trait}} dataset for comparative analyses using \code{\link{AncCond}}. Loaded as the object \code{trees}.}
+\examples{
+data(trees.mite)
+plot(trees[[1]])
+}
 \keyword{datasets}

--- a/man/trees.nex.Rd
+++ b/man/trees.nex.Rd
@@ -1,6 +1,6 @@
 \name{trees.nex}
 \alias{trees.nex}
 \docType{data}
-\title{100 Phylogenetic trees}
-\description{This is a collection of 100 simulated phylogenetic trees with 10 tips each.}
+\title{100 simulated phylogenetic trees}
+\description{A nexus-format file containing a collection of 100 simulated phylogenetic trees, each with 10 tips. Stored in the \code{inst/} directory. Used in examples for the \code{\link{SampleTrees}} function to demonstrate tree subsampling from posterior distributions.}
 \keyword{datasets}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(evobiR)
+
+test_check("evobiR")

--- a/tests/testthat/test-CalcD.R
+++ b/tests/testthat/test-CalcD.R
@@ -1,0 +1,19 @@
+test_that("CalcD returns a numeric D-statistic", {
+  result <- CalcD(alignment = system.file("1.fasta", package = "evobiR"),
+                  sig.test = "N")
+  expect_true(is.numeric(result))
+  expect_true(result >= -1 && result <= 1)
+})
+
+test_that("CalcPopD returns a list with required elements", {
+  result <- CalcPopD(alignment = system.file("3.fasta", package = "evobiR"),
+                     sig.test = "N")
+  expect_true(is.list(result))
+  expect_true("d.stat" %in% names(result))
+})
+
+test_that("CalcD with bootstrap returns numeric", {
+  result <- CalcD(alignment = system.file("1.fasta", package = "evobiR"),
+                  sig.test = "B", replicate = 10)
+  expect_true(is.numeric(result))
+})

--- a/tests/testthat/test-FuzzyMatch.R
+++ b/tests/testthat/test-FuzzyMatch.R
@@ -1,0 +1,14 @@
+test_that("FuzzyMatch returns a dataframe", {
+  data(hym.tree)
+  names <- c("Pepsis_elegans", "Pheidele_lucreti")
+  result <- FuzzyMatch(tree = hym.tree, data = names, max.dist = 3)
+  expect_true(is.data.frame(result))
+})
+
+test_that("FuzzyMatch finds close matches", {
+  data(hym.tree)
+  # Intentionally misspelled names
+  names <- c("Pepsis_elegans")
+  result <- FuzzyMatch(tree = hym.tree, data = names, max.dist = 3)
+  expect_true(nrow(result) >= 0)
+})

--- a/tests/testthat/test-Pfsa.R
+++ b/tests/testthat/test-Pfsa.R
@@ -1,0 +1,25 @@
+test_that("Pfsa, Pfaa, Pfss sum to 1", {
+  pfsa <- Pfsa(Da = 26, scs = "XY", mud = 0.4)
+  pfaa <- Pfaa(Da = 26, scs = "XY", mud = 0.4)
+  pfss <- Pfss(Da = 26, scs = "XY", mud = 0.4)
+  expect_equal(pfsa + pfaa + pfss, 1, tolerance = 1e-10)
+})
+
+test_that("Pfsa returns numeric of length 1", {
+  result <- Pfsa(Da = 26, scs = "XY", mud = 0.4)
+  expect_true(is.numeric(result))
+  expect_equal(length(result), 1)
+  expect_true(result >= 0 && result <= 1)
+})
+
+test_that("Pfsa works with XO system", {
+  result <- Pfsa(Da = 20, scs = "XO", mud = 0.5)
+  expect_true(is.numeric(result))
+  expect_true(result >= 0 && result <= 1)
+})
+
+test_that("Pfsa works with ZW system", {
+  result <- Pfsa(Da = 20, scs = "ZW", mud = 0.5)
+  expect_true(is.numeric(result))
+  expect_true(result >= 0 && result <= 1)
+})

--- a/tests/testthat/test-ResSel.R
+++ b/tests/testthat/test-ResSel.R
@@ -1,0 +1,8 @@
+test_that("ResSel returns a list with high and low lines", {
+  data <- read.csv(file = system.file("horn.beetle.csv", package = "evobiR"))
+  result <- ResSel(data = data, traits = c(2, 3), percent = 15,
+                   identifier = 1, model = "linear")
+  expect_true(is.list(result))
+  expect_true("high line" %in% names(result))
+  expect_true("low line" %in% names(result))
+})

--- a/tests/testthat/test-SlidingWindow.R
+++ b/tests/testthat/test-SlidingWindow.R
@@ -1,0 +1,21 @@
+test_that("SlidingWindow works on vectors", {
+  x <- 1:100
+  result <- SlidingWindow(FUN = "mean", data = x, window = 10, step = 5, strict = TRUE)
+  expect_true(is.numeric(result))
+  expect_true(length(result) > 0)
+  # first window should be mean of 1:10 = 5.5
+  expect_equal(result[1], 5.5)
+})
+
+test_that("SlidingWindow works on matrices", {
+  x <- matrix(1:100, 10, 10)
+  result <- SlidingWindow(FUN = "mean", data = x, window = 5, step = 3, strict = TRUE)
+  expect_true(is.matrix(result))
+})
+
+test_that("SlidingWindow handles different functions", {
+  x <- 1:100
+  result_sd <- SlidingWindow(FUN = "sd", data = x, window = 10, step = 10, strict = TRUE)
+  expect_true(is.numeric(result_sd))
+  expect_true(all(result_sd > 0))
+})

--- a/tests/testthat/test-getNe.R
+++ b/tests/testthat/test-getNe.R
@@ -1,0 +1,17 @@
+test_that("getNe returns numeric value", {
+  result <- getNe(males = 100, females = 200)
+  expect_true(is.numeric(result))
+  expect_equal(length(result), 1)
+})
+
+test_that("getNe with equal sex ratio returns expected value", {
+  # With equal numbers, Ne = N
+  result <- getNe(males = 100, females = 100)
+  expect_equal(result, 200)
+})
+
+test_that("getNe works for X-linked locus", {
+  result <- getNe(males = 100, females = 200, locus = "X")
+  expect_true(is.numeric(result))
+  expect_equal(length(result), 1)
+})

--- a/vignettes/evolutionary.biology.in.R.Rmd
+++ b/vignettes/evolutionary.biology.in.R.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Evolutionary biology in R (evobiR) tutorial"
-author: "Michelle Jonika, Jeffery Demuth, and Richard A. Adams, and Heath Blackmon "
+author: "Michelle Jonika, Jeffery Demuth, Richard H. Adams, and Heath Blackmon"
 date: "last updated: `r Sys.Date()`"
 output:
   rmarkdown::html_vignette:
@@ -15,7 +15,7 @@ vignette: >
 _______
 # Installing
 
-The most recent version may be installed from github using the devtools package: 
+The most recent version may be installed from github using the devtools package:
 
 Installing from github
 
@@ -29,15 +29,15 @@ library(evobiR)
 _______
 # Comparative Methods
 
-## AncCond: 
-```{}
+## AncCond
+```{r, eval=FALSE}
 data(mite.trait)
 data(trees.mite)
-AncCond(trees[[1]], mite.trait) 
+AncCond(trees[[1]], mite.trait)
 ```
 
 This function uses stochastic mapping and ancestral state reconstruction to determine if the derived state of a binary trait originates when a continuous trait has an extreme value.
- 
+
 <img src="./images/anccond.png" width="500" height="500"/>
 
 The four steps in the ancestral condition test. A) Ancestral states are estimated for the continuous character assuming a Brownian motion model of evolution. B) Possible evolutionary histories for the discrete trait are generated through stochastic mapping C) Nodes are categorized as either ancestral or derived, and ancestral nodes that subtend an origin of the derived state of the discrete character are annotated. D) Depiction of the null distribution and the observed mean of producing nodes estimated from the data. In this example the producing nodes have a lower continuous value than expected if there is no relationship between the traits.
@@ -45,11 +45,11 @@ The four steps in the ancestral condition test. A) Ancestral states are estimate
 &nbsp;
 
 
- 
-&nbsp;
- 
 
- 
+&nbsp;
+
+
+
 ## FuzzyMatch
 When assembling data from different sources typos can sometimes cause a loss of perfect matches between trees and datasets. This function helps you find these close matches that can be hand curated to keep as many species as possible in your analysis.
 
@@ -60,19 +60,19 @@ FuzzyMatch(tree = hym.tree, data = names, max.dist=3)
 ```
 
 &nbsp;
- 
+
 
 &nbsp;
 
 
 ## SampleTrees
 
-```{r, eval=F}
-SampleTrees(trees = system.file("trees.nex", package = "evobiR"), 
+```{r, eval=FALSE}
+SampleTrees(trees = system.file("trees.nex", package = "evobiR"),
             burnin = .1, final.number = 20, format = 'new', prefix = 'sample')
 ```
 
-This function takes as its input a large collection of trees from a program like MrBayes or Beast and allows the user to select the number of randomly drawn trees they wish to retrieve and to save them in either newick or nexus format.
+This function takes as its input a large collection of trees from a program like MrBayes or BEAST and allows the user to select the number of randomly drawn trees they wish to retrieve and to save them in either Newick or Nexus format.
 
 
 &nbsp;
@@ -83,9 +83,56 @@ This function takes as its input a large collection of trees from a program like
 
 ## SuperMatrix
 
-`SuperMatrix(missing = "N", prefix = "DATASET2", save = T)`
+`SuperMatrix(missing = "N", prefix = "DATASET2", save = TRUE)`
 
-This function reads all fasta format alignments in the working directory and constructs a single supermatrix that includes all taxa present in any of the fasta files and inserts missing symbols for taxa that are missing sequences for some loci.  A list with two elements is returned. The first element contains partition data that records the alignment positions of each input fasta file in the combined supermatrix. The second element is a dataframe version of the supermatrix. If the argument save is set to True then both of these files are also saved to the working directory.
+This function reads all fasta format alignments in the working directory and constructs a single supermatrix that includes all taxa present in any of the fasta files and inserts missing symbols for taxa that are missing sequences for some loci.  A list with two elements is returned. The first element contains partition data that records the alignment positions of each input fasta file in the combined supermatrix. The second element is a dataframe version of the supermatrix. If the argument save is set to TRUE then both of these files are also saved to the working directory.
+
+&nbsp;
+
+_______
+# Phylogenetic Rate Analysis
+
+## scaleTreeRates & plot.phyloscaled
+
+The `scaleTreeRates` function analyzes heterogeneity in rates of discrete character evolution across a phylogeny. It estimates a scalar multiplier for each edge that modifies the overall transition rate matrix, allowing rates to vary across the tree.
+
+```{r, eval=FALSE}
+library(ape)
+library(phytools)
+
+## Fit rate heterogeneity model
+tree <- rtree(20)
+tip.states <- sample(1:2, 20, replace = TRUE)
+names(tip.states) <- tree$tip.label
+result <- scaleTreeRates(tree, tip.states, model = "ER", nbins = 3)
+
+## Visualize with scaled branch lengths
+plot(result, method = "multiply")
+
+## Visualize with colored branches
+plot(result, method = "color")
+```
+
+The `plot.phyloscaled` function provides two visualization methods: `"multiply"` scales branch lengths by their associated scalar, and `"color"` assigns colors from a diverging palette to indicate rate variation.
+
+&nbsp;
+
+## make.simmap2 & fix.simmap
+
+The `make.simmap2` function is an extension of phytools' `make.simmap` that adds rejection monitoring and a maximum rejection limit per edge. When the rejection limit is exceeded, the edge is assigned a "fail" state rather than stalling the simulation. The `fix.simmap` function uses graph theory to resolve these failed edges.
+
+```{r, eval=FALSE}
+library(ape)
+library(phytools)
+tree <- rtree(20)
+x <- sample(c("a","b"), 20, replace = TRUE)
+names(x) <- tree$tip.label
+
+## Run stochastic mapping with rejection limit
+result <- make.simmap2(tree, x, model = "ER", nsim = 10,
+                       monitor = FALSE, rejmax = 100000)
+```
+
 
 &nbsp;
 
@@ -93,7 +140,7 @@ _______
 # Population Genetics
 
 ## CalcD & WinCalcD
-The functions CalcD and CalcPopD are implementations of the algorithm introgression in genomic data. Significance of the D-stat can be calculated either through bootstrapping or jackknifing. Bootstrapping is appropriate for datasets where SNPs are unlinked for instance unmapped RADSeq data. Jackknifing is the appropriate approach when SNPs are potentially in linkage for instance gene alignments or genome alignments. The WinCalcD function is identical to CalcD but performs testing in windows along an alignment.
+The functions CalcD and CalcPopD are implementations of the algorithm for detecting introgression in genomic data. Significance of the D-statistic can be calculated either through bootstrapping or jackknifing. Bootstrapping is appropriate for datasets where SNPs are unlinked, for instance unmapped RADSeq data. Jackknifing is the appropriate approach when SNPs are potentially in linkage, for instance gene alignments or genome alignments. The WinCalcD function is identical to CalcD but performs testing in windows along an alignment.
 
 Durand, Eric Y., et al. Testing for ancient admixture between closely related populations. Molecular biology and evolution 28.8 (2011): 2239-2252.
 
@@ -105,6 +152,33 @@ CalcD(alignment = system.file("1.fasta", package = "evobiR"), sig.test = "N")
 
 CalcPopD(alignment = system.file("3.fasta", package = "evobiR"), sig.test = "N")
 
+```
+
+## getNe
+
+Calculate the variance effective population size due to unequal sex ratio. Formulas are available for both autosomal loci and X chromosome loci.
+
+```{r}
+# Effective population size for autosomal locus
+getNe(males = 100, females = 200)
+
+# Effective population size for X-linked locus
+getNe(males = 100, females = 200, locus = "X")
+```
+
+## Pfsa, Pfaa, Pfss
+
+These functions calculate the expected proportion of different classes of chromosomal fusions (sex chromosome-autosome, autosome-autosome, and sex chromosome-sex chromosome) given a sex chromosome system and diploid autosome number.
+
+```{r}
+# Proportion of sex-autosome fusions
+Pfsa(Da = 26, scs = "XY", mud = 0.4)
+
+# Proportion of autosome-autosome fusions
+Pfaa(Da = 26, scs = "XY", mud = 0.4)
+
+# Proportion of sex-sex chromosome fusions
+Pfss(Da = 26, scs = "XY", mud = 0.4)
 ```
 
 
@@ -127,27 +201,30 @@ plot(foo, ylab="Number of sunspots", xlab="record number")
 When we look at the data at this scale the pattern that really catches our attention is the 25 peaks that we see across these 260 years.  This is the well documented 11-year sunspot cycle.  However, our sun has longer cycles that are less evident in this graphing.
 
 ```{r, fig.height=5, fig.width=5}
-# first lets use the sliding window function to get the number sun spots 
+# first lets use the sliding window function to get the number sun spots
 
 # average over 11 years and do this moving in 1 year steps through time
-sunspots <- SlidingWindow(FUN = "mean", 
-                          data = foo, 
-                          window = 132, 
-                          step = 12, 
+sunspots <- SlidingWindow(FUN = "mean",
+                          data = foo,
+                          window = 132,
+                          step = 12,
                           strict = F)
 
-# we repeat this on the years so we can plot agains a sensible x axis
-years <- round(SlidingWindow("mean", 
-                             data = rep(1749:2013, each=12)[1:3177], 
-                             window = 132, 
-                             step = 12, 
+# generate year labels using the length of the data
+n.months <- length(foo)
+start.year <- 1749
+year.seq <- rep(start.year:(start.year + ceiling(n.months/12) - 1), each = 12)[1:n.months]
+years <- round(SlidingWindow("mean",
+                             data = year.seq,
+                             window = 132,
+                             step = 12,
                              strict=F))
 {plot(x=years,y=sunspots, type="l", lwd=3)
 abline(v=1810, col="red",lwd=3)
 text(y=90, x=1810, "Dalton Min.", col="red",pos=4)}
 ```
 
-now we can easily spot just how exceptional the Dalton minimum of the early 1800s was.
+Now we can easily spot just how exceptional the Dalton minimum of the early 1800s was.
 
 &nbsp;
 
@@ -164,7 +241,7 @@ The first column of the data file should contain the identifier i.e. the specime
 data[1:10,]
 ```
 
-We can then run the residual selection function and it will provide us with both a visual depiction of the data and will return a list with elements (high line and low line providing us with ID numbers of selected individuals.
+We can then run the residual selection function and it will provide us with both a visual depiction of the data and will return a list with elements (high line and low line) providing us with ID numbers of selected individuals.
 
 ```{r, fig.height=5, fig.width=5}
 ResSel(data = data, traits = c(2,3), percent = 15, identifier = 1, model = "linear")


### PR DESCRIPTION
## Summary

Comprehensive quality review bringing evobiR up to community standards:

- **Fix 8 critical bugs** in core functions (AncCond, GetTipRates, CalcPopD, WinCalcD, FuzzyMatch, countTrees, make.simmap2)
- **Update all 24 help files** with corrected typos, improved descriptions, added examples, and proper `\value{}` sections
- **Expand vignette** with sections for newer functions (scaleTreeRates, make.simmap2, getNe, Pfsa/Pfaa/Pfss)
- **Add testthat infrastructure** with tests for CalcD, SlidingWindow, Pfsa, getNe, FuzzyMatch, and ResSel
- **Add GitHub Actions CI/CD** (R-CMD-check on macOS + Ubuntu, release + devel)
- **Add inst/CITATION** and `.Rbuildignore`
- **Bump version** to 2.2

### Bug fixes
| File | Bug |
|------|-----|
| `R/AncCond.R` | Inverted input validation rejected valid inputs; deprecated `is()` call; wrong logical operator in data check |
| `R/GetTipRates.R` | Inverted `is.integer()` check stopped valid integer inputs |
| `R/CalcD.R` | `CalcPopD` missing explicit `return()` statement |
| `R/WinCalcD.R` | Debug `cat()`/`print()` statements left in production code |
| `R/FuzzyMatch.R` | Deprecated `is()` instead of `inherits()` |
| `R/countTrees.R` | Warning message says "do match" instead of "do not match" |
| `R/make.simmap2.R` | Global assignment with `<<-` replaced with `for` loop |

## Test plan
- [ ] `R CMD check` passes with no errors or warnings
- [ ] `devtools::test()` runs all new tests successfully
- [ ] `devtools::run_examples()` executes without errors
- [ ] Vignette builds cleanly with `devtools::build_vignettes()`
- [ ] GitHub Actions CI/CD passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)